### PR TITLE
Add option to swap Settings and Clear

### DIFF
--- a/data/net.launchpad.indicator.notifications.gschema.xml.in.in
+++ b/data/net.launchpad.indicator.notifications.gschema.xml.in.in
@@ -31,5 +31,10 @@
       <summary>Maximum number of visible items</summary>
       <description>The indicator will only display at most the number of notifications indicated by this value.</description>
     </key>
+    <key name="swap-clear-settings" type="b">
+      <default>false</default>
+      <summary>Swap the Clear and Settings items in the menu</summary>
+      <description>This will move the Clear option to the bottom of the menu, below the Settings item.</description>
+    </key>
   </schema>
 </schemalist>

--- a/src/indicator-notifications-settings.c
+++ b/src/indicator-notifications-settings.c
@@ -231,6 +231,7 @@ indicator_notifications_settings_activate(GApplication *app)
   GtkWidget *button_cmc;
   GtkWidget *button_hide_ind;
   GtkWidget *button_dnd;
+  GtkWidget *button_swap_clr_s;
   GtkWidget *spin;
   GtkWidget *spin_label;
   GtkWidget *blacklist_label;
@@ -300,6 +301,15 @@ indicator_notifications_settings_activate(GApplication *app)
   g_signal_connect(button_dnd, "toggled", G_CALLBACK(button_toggled_cb), self->settings);
   gtk_box_pack_start(GTK_BOX(vbox), button_dnd, FALSE, FALSE, 4);
   gtk_widget_show(button_dnd);
+
+  /* swap-clear-settings */
+  button_swap_clr_s = gtk_check_button_new_with_label(_("Swap \"Clear\" and \"Settings\" items"));
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button_swap_clr_s),
+      g_settings_get_boolean(self->settings, NOTIFICATIONS_KEY_SWAP_CLEAR_SETTINGS));
+  g_object_set_data(G_OBJECT(button_swap_clr_s), SCHEMA_KEY, NOTIFICATIONS_KEY_SWAP_CLEAR_SETTINGS);
+  g_signal_connect(button_swap_clr_s, "toggled", G_CALLBACK(button_toggled_cb), self->settings);
+  gtk_box_pack_start(GTK_BOX(vbox), button_swap_clr_s, FALSE, FALSE, 4);
+  gtk_widget_show(button_swap_clr_s);
 
   /* max-items */
   /* FIXME: indicator does not change max items until restart... */

--- a/src/indicator-notifications.c
+++ b/src/indicator-notifications.c
@@ -64,6 +64,7 @@ struct _IndicatorNotificationsPrivate {
   gboolean     do_not_disturb;
   gboolean     have_unread;
   gboolean     hide_indicator;
+  gboolean     swap_clear_settings;
 
   gint         max_items;
 
@@ -127,6 +128,7 @@ static void save_blacklist_hints(IndicatorNotifications *self);
 static void update_blacklist_hints(IndicatorNotifications *self, Notification *notification);
 static void update_do_not_disturb(IndicatorNotifications *self);
 static void settings_try_set_boolean(const gchar *schema, const gchar *key, gboolean value);
+static void swap_clear_settings_items(IndicatorNotifications *self);
 
 /* Callbacks */
 static void clear_item_activated_cb(GtkMenuItem *menuitem, gpointer user_data);
@@ -217,6 +219,9 @@ indicator_notifications_init(IndicatorNotifications *self)
   self->priv->hide_indicator = g_settings_get_boolean(self->priv->settings, NOTIFICATIONS_KEY_HIDE_INDICATOR);
   self->priv->max_items = g_settings_get_int(self->priv->settings, NOTIFICATIONS_KEY_MAX_ITEMS);
   update_blacklist(self);
+  self->priv->swap_clear_settings = g_settings_get_boolean(self->priv->settings, NOTIFICATIONS_KEY_SWAP_CLEAR_SETTINGS);
+  if(self->priv->swap_clear_settings)
+    swap_clear_settings_items(self);
   g_signal_connect(self->priv->settings, "changed", G_CALLBACK(setting_changed_cb), self);
 
   /* Set up blacklist hints */
@@ -691,6 +696,27 @@ settings_try_set_boolean(const gchar *schema, const gchar *key, gboolean value)
 }
 
 /**
+ * swap_clear_settings_items:
+ * @self: the indicator object
+ *
+ * Swaps the position of the clear and settings items.
+ **/
+static void
+swap_clear_settings_items(IndicatorNotifications *self)
+{
+  g_return_if_fail(IS_INDICATOR_NOTIFICATIONS(self));
+
+  // Pick which widget to move
+  GtkWidget *widget = self->priv->settings_item;
+  if(self->priv->swap_clear_settings)
+    widget = self->priv->clear_item;
+
+  gtk_container_remove(GTK_CONTAINER(self->priv->menu), g_object_ref(widget));
+  gtk_menu_shell_append(GTK_MENU_SHELL(self->priv->menu), widget);
+  g_object_unref(widget);
+}
+
+/**
  * clear_item_activated_cb:
  * @menuitem: the clear menuitem
  * @user_data: the indicator object
@@ -763,6 +789,10 @@ setting_changed_cb(GSettings *settings, gchar *key, gpointer user_data)
   }
   else if(g_strcmp0(key, NOTIFICATIONS_KEY_BLACKLIST) == 0) {
     update_blacklist(self);
+  }
+  else if(g_strcmp0(key, NOTIFICATIONS_KEY_SWAP_CLEAR_SETTINGS) == 0) {
+    self->priv->swap_clear_settings = g_settings_get_boolean(self->priv->settings, NOTIFICATIONS_KEY_SWAP_CLEAR_SETTINGS);
+    swap_clear_settings_items(self);
   }
   /* TODO: Trim or extend the notifications list based on "max-items" key
    * (Currently requires a restart) */

--- a/src/settings.h
+++ b/src/settings.h
@@ -5,13 +5,14 @@
 #ifndef __SETTINGS_H__
 #define __SETTINGS_H__
 
-#define NOTIFICATIONS_SCHEMA              "net.launchpad.indicator.notifications"
-#define NOTIFICATIONS_KEY_BLACKLIST       "blacklist"
-#define NOTIFICATIONS_KEY_BLACKLIST_HINTS "blacklist-hints"
-#define NOTIFICATIONS_KEY_CLEAR_MC        "clear-on-middle-click"
-#define NOTIFICATIONS_KEY_DND             "do-not-disturb"
-#define NOTIFICATIONS_KEY_HIDE_INDICATOR  "hide-indicator"
-#define NOTIFICATIONS_KEY_MAX_ITEMS       "max-items"
+#define NOTIFICATIONS_SCHEMA                  "net.launchpad.indicator.notifications"
+#define NOTIFICATIONS_KEY_BLACKLIST           "blacklist"
+#define NOTIFICATIONS_KEY_BLACKLIST_HINTS     "blacklist-hints"
+#define NOTIFICATIONS_KEY_CLEAR_MC            "clear-on-middle-click"
+#define NOTIFICATIONS_KEY_DND                 "do-not-disturb"
+#define NOTIFICATIONS_KEY_HIDE_INDICATOR      "hide-indicator"
+#define NOTIFICATIONS_KEY_MAX_ITEMS           "max-items"
+#define NOTIFICATIONS_KEY_SWAP_CLEAR_SETTINGS "swap-clear-settings"
 
 #define MATE_SCHEMA  "org.mate.NotificationDaemon"
 #define MATE_KEY_DND "do-not-disturb"


### PR DESCRIPTION
This commit adds an option to swap the `Settings` and `Clear` items in the menu, effectively moving the `Clear` item back to the bottom of the menu.

Being a long time user of this indicator, I have developed muscle memory to always hit the last item in the menu to clear the notifications.

I upgraded recently to the latest version (which has the `Settings` item at the bottom of the menu), resulting in me constantly clicking `Settings` instead of `Clear`, and it's been extremely frustrating.

I do realise that not everyone may expect this behaviour, which is why I made this a configurable option. It does not require a restart for changes to take effect.